### PR TITLE
docker compose環境を整備する

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM node:14
-RUN apt-get update && mkdir /app && npm i -g typescript
+
+RUN apt-get update && mkdir /app
 WORKDIR /app
-RUN npm install
-# なぜかこれが動かない。
-CMD [ "/usr/local/bin/tsc", "--watch", "/app/src/index.ts" ]
+
+COPY package.json package-lock.json /app/
+RUN npm ci

--- a/README.md
+++ b/README.md
@@ -51,9 +51,17 @@
 全員がドライバー回せるかは状況次第です。回らなかった場合は次週の勉強会で優先的にドライバーをやってもらおうと思っています。
 
 # プロジェクト開始方法
+
+## docker-compose
 ```sh
-$ bash docker-build.sh
+$ docker compose up --build
 ...building image...
+...jestのwatchモードが動き出す...
+$ docker compose exec node bash # shell入りたいとき
+```
+
+## docker
+```sh
 $ bash docker-run.sh
 // run docker container
 // tsc --watch /app/src/index.ts
@@ -62,3 +70,4 @@ $ bash docker-login.sh
 # npm test
 // jest
 ```
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,10 +3,8 @@ version: "3.8"
 services: 
   node:
     build: ./
+    command: npm test -- --watchAll
     volumes: 
       - ./:/app
-      - node_modules:/app/node_modules
+      - /app/node_modules
     tty: true
-
-volumes:
-  node_modules:

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,8 @@
 module.exports = {
-  roots: ["/app/test"],
+  roots: [
+    "/app/src",
+    "/app/test",
+  ],
   testMatch: [
     "**/__tests__/**/*.+(ts|tsx|js)",
     "**/?(*.)+(spec|test).+(ts|tsx|js)",


### PR DESCRIPTION
`docker compose up`したらそれでokな感じにできると幸せかと思い調整してみました。

方針
- node_modulesはローカルにおかずにイメージの中にいれちゃう（要件的に滅多にパッケージ追加しないはずなので）
- docker-composeのコマンドでjest watchAllする（他にコマンド実行する要件なさそう）
- tscでの型チェックはエディタに任せる
- 元からあったdockerコマンドのshellはとりあえず残す

手数減って楽かなーと思いますがどうでしょう。